### PR TITLE
fixed Swift 3.1 warnings

### DIFF
--- a/Example/HGCircularSlider.xcodeproj/project.pbxproj
+++ b/Example/HGCircularSlider.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
@@ -511,6 +511,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04EAC630898381E6412A72E4 /* Pods-HGCircularSlider_Example.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = HGCircularSlider/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -525,6 +526,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9BA305BCC009CE17283FE799 /* Pods-HGCircularSlider_Example.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = HGCircularSlider/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/HGCircularSlider.xcodeproj/xcshareddata/xcschemes/HGCircularSlider-Example.xcscheme
+++ b/Example/HGCircularSlider.xcodeproj/xcshareddata/xcschemes/HGCircularSlider-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/HGCircularSlider/Classes/CircularSliderHelper.swift
+++ b/HGCircularSlider/Classes/CircularSliderHelper.swift
@@ -97,8 +97,8 @@ extension CGRect {
 class CircularSliderHelper {
     
     @nonobjc static let circleMinValue: CGFloat = 0
-    @nonobjc static let circleMaxValue: CGFloat = CGFloat(2 * M_PI)
-    @nonobjc static let circleInitialAngle: CGFloat = -CGFloat(M_PI_2)
+    @nonobjc static let circleMaxValue: CGFloat = CGFloat(2 * Double.pi)
+    @nonobjc static let circleInitialAngle: CGFloat = -CGFloat(Double.pi / 2)
     
     /**
      Convert angle from radians to degrees
@@ -108,7 +108,7 @@ class CircularSliderHelper {
      - returns: degree value
      */
     internal static func degrees(fromRadians value: CGFloat) -> CGFloat {
-        return value * 180.0 / CGFloat(M_PI)
+        return value * 180.0 / CGFloat(Double.pi)
     }
 
     /**
@@ -133,7 +133,7 @@ class CircularSliderHelper {
         let angle = atan2(uv.determinant, uv.dotProduct)
         
         // change the angle interval
-        let newAngle = (angle < 0) ? -angle : Float(2 * M_PI) - angle
+        let newAngle = (angle < 0) ? -angle : Float(2 * Double.pi) - angle
         
         return CGFloat(newAngle)
     }


### PR DESCRIPTION
Hi,

If you use your project in Xcode 8.3 / Swift 3.1 you'll get a few warnings to not use M_PI but Double.pi.
This pull request fixes this.

Thank you for your library!