### PR TITLE
Enable different initial angle for circular slider.

### DIFF
--- a/Example/HGCircularSlider/Base.lproj/Main.storyboard
+++ b/Example/HGCircularSlider/Base.lproj/Main.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="sp2-vV-rZV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="sp2-vV-rZV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -154,7 +153,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IfT-Jw-FAY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1254.5" y="2467.5"/>
+            <point key="canvasLocation" x="-2007.2" y="2219.6401799100449"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="M9S-pb-Waq">
@@ -177,7 +176,7 @@
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gDj-DB-klF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-327" y="1633"/>
+            <point key="canvasLocation" x="-523.20000000000005" y="1468.9655172413795"/>
         </scene>
         <!--Player-->
         <scene sceneID="90r-0D-nKE">
@@ -290,7 +289,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LfZ-7G-N6b" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-794" y="2468"/>
+            <point key="canvasLocation" x="-1270.4000000000001" y="2220.089955022489"/>
         </scene>
         <!--Example-->
         <scene sceneID="stQ-nu-pyE">
@@ -382,7 +381,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="11N-ZE-qqz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-326" y="2468"/>
+            <point key="canvasLocation" x="-521.60000000000002" y="2220.089955022489"/>
         </scene>
         <!--OClock-->
         <scene sceneID="qvZ-oN-u0x">
@@ -584,7 +583,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4jZ-R1-SB1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="148" y="2468"/>
+            <point key="canvasLocation" x="236.80000000000001" y="2220.089955022489"/>
         </scene>
         <!--Circular-->
         <scene sceneID="EVO-nS-JTv">
@@ -602,7 +601,7 @@
                                 <rect key="frame" x="46" y="152" width="283" height="283"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Rounds" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eTZ-Q0-WV1">
-                                        <rect key="frame" x="111" y="131.5" width="62" height="20.5"/>
+                                        <rect key="frame" x="110.5" y="131.5" width="62" height="20.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                         <color key="textColor" red="0.1843137255" green="0.21960784310000001" blue="0.53725490200000003" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -619,10 +618,7 @@
                                         <real key="value" value="0.0"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="maximumValue">
-                                        <real key="value" value="30"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfRounds">
-                                        <integer key="value" value="3"/>
+                                        <real key="value" value="1000"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="trackFillColor">
                                         <color key="value" red="0.1843137255" green="0.21960784310000001" blue="0.53725490200000003" alpha="1" colorSpace="calibratedRGB"/>
@@ -646,10 +642,16 @@
                                         <color key="value" red="0.67450980392156867" green="0.18823529411764706" blue="0.39215686274509803" alpha="1" colorSpace="calibratedRGB"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="diskFillColor">
-                                        <color key="value" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="color" keyPath="diskColor">
-                                        <color key="value" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <color key="value" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="numberOfRounds">
+                                        <integer key="value" value="1"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="circleInitialAngle">
+                                        <real key="value" value="1.5700000000000001"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
@@ -736,7 +738,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ijD-qf-fmt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="643" y="2468"/>
+            <point key="canvasLocation" x="1028.8" y="2220.089955022489"/>
         </scene>
     </scenes>
     <resources>
@@ -747,9 +749,4 @@
         <image name="second" width="30" height="30"/>
         <image name="time_indicators" width="301" height="300"/>
     </resources>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
-    </simulatedMetricsContainer>
 </document>

--- a/Example/HGCircularSlider/CircularSliderViewController.swift
+++ b/Example/HGCircularSlider/CircularSliderViewController.swift
@@ -21,7 +21,6 @@ class CircularSliderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        circularSlider.endPointValue = 1
         updateTexts()
         circularSlider.addTarget(self, action: #selector(updateTexts), for: .valueChanged)
     }

--- a/HGCircularSlider/Classes/CircularSlider.swift
+++ b/HGCircularSlider/Classes/CircularSlider.swift
@@ -212,9 +212,19 @@ open class CircularSlider: UIControl {
             setNeedsDisplay()
         }
     }
-    
+
+    /**
+     * Angle in radians of the starting point for the track. Defaults to -∏/2 (top position).
+     */
+    @IBInspectable
+    open var circleInitialAngle: CGFloat = CircularSliderHelper.circleInitialAngle {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
     // MARK: init methods
-    
+
     /**
      See superclass documentation
      */
@@ -250,9 +260,9 @@ open class CircularSlider: UIControl {
         
         let valuesInterval = Interval(min: minimumValue, max: maximumValue, rounds: numberOfRounds)
         // get end angle from end value
-        let endAngle = CircularSliderHelper.scaleToAngle(value: endPointValue, inInterval: valuesInterval) + CircularSliderHelper.circleInitialAngle
+        let endAngle = CircularSliderHelper.scaleToAngle(value: endPointValue, inInterval: valuesInterval) + circleInitialAngle
         
-        drawFilledArc(fromAngle: CircularSliderHelper.circleInitialAngle, toAngle: endAngle, inContext: context)
+        drawFilledArc(fromAngle: circleInitialAngle, toAngle: endAngle, inContext: context)
         
         // draw end thumb
         endThumbTintColor.setFill()
@@ -282,7 +292,8 @@ open class CircularSlider: UIControl {
     override open func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {
         // the position of the pan gesture
         let touchPosition = touch.location(in: self)
-        let startPoint = CGPoint(x: bounds.center.x, y: 0)
+        let centerPoint = CGPoint(x: bounds.maxX, y: bounds.center.y)
+        let startPoint = centerPoint.rotate(around: bounds.center, with: circleInitialAngle)
         let value = newValue(from: endPointValue, touch: touchPosition, start: startPoint)
         
         endPointValue = value
@@ -304,14 +315,10 @@ open class CircularSlider: UIControl {
         let interval = Interval(min: minimumValue, max: maximumValue, rounds: numberOfRounds)
         let deltaValue = CircularSliderHelper.delta(in: interval, for: angle, oldValue: oldValue)
         
-        var newValue = oldValue + deltaValue
-        let range = maximumValue - minimumValue
+        let newValue = oldValue + deltaValue
         
-        if newValue > maximumValue {
-            newValue -= range
-        }
-        else if newValue < minimumValue {
-            newValue += range
+        if !(minimumValue...maximumValue ~= newValue) {
+            return oldValue
         }
         return newValue
     }

--- a/HGCircularSlider/Classes/CircularSliderHelper.swift
+++ b/HGCircularSlider/Classes/CircularSliderHelper.swift
@@ -97,6 +97,20 @@ internal extension CGRect {
     }
 }
 
+extension CGPoint {
+    
+    func rotate(around center: CGPoint, with radians: CGFloat) -> CGPoint {
+        let dx = self.x - center.x
+        let dy = self.y - center.y
+        let radius = sqrt(dx * dx + dy * dy)
+        let azimuth = atan2(dy, dx)
+        let newAzimuth = azimuth + radians
+        let x = center.x + radius * cos(newAzimuth)
+        let y = center.y + radius * sin(newAzimuth)
+        return CGPoint(x: x, y: y)
+    }
+}
+
 // MARK: - Internal Helper
 internal class CircularSliderHelper {
     


### PR DESCRIPTION
This PR addresses the issue #20: Setting the start position.

It is based on solution by @spaluchiewicz and [this PR](https://github.com/HamzaGhazouani/HGCircularSlider/pull/21). I was unable to update the existing PR due to the access rights so I'm setting up a new one.
Commits are squashed to keep it clean, but @spaluchiewicz is kept as the coauthor. I hope this is fine.

In addition to setting the new position, I also tweaked the current implementation so that user can't swipe over the maximum and under the minimum value. Please let me know if you think it's appropriate or if we should make it a property that can be set.