### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/HGCircularSlider/Classes/MidPointCircularSlider.swift
+++ b/HGCircularSlider/Classes/MidPointCircularSlider.swift
@@ -6,6 +6,8 @@
 //
 //
 
+import UIKit
+
 /**
  A visual control used to select a fixed range of values from a continuous range of values.
  MidPointCircularSlider use the target-action mechanism to report changes made during the course of editing:

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "HGCircularSlider",
+    platforms: [.iOS(.v8)],
+    products: [
+        .library(
+            name: "HGCircularSlider",
+            targets: ["HGCircularSlider"]
+        )
+    ],
+    targets: [
+        .target(name: "HGCircularSlider", path: "HGCircularSlider/Classes")
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM and closes #57.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.