### PR TITLE
Enable MidPointCircularSlider to have subclass

### DIFF
--- a/HGCircularSlider/Classes/MidPointCircularSlider.swift
+++ b/HGCircularSlider/Classes/MidPointCircularSlider.swift
@@ -91,7 +91,7 @@ open class MidPointCircularSlider: RangeCircularSlider {
         distance = 0.2
     }
     
-    override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         distance = 0.2
     }


### PR DESCRIPTION
Added 'public' keyword to enable MidPointCircularSlider to have subclass.